### PR TITLE
Feat: run certificate and health checks async to speed up alerting time

### DIFF
--- a/health_check.go
+++ b/health_check.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"github.com/hashicorp/go-retryablehttp"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"strings"
+	"sync"
+	"time"
 )
 
 type HealthCheck struct {
@@ -20,48 +24,103 @@ type HealthCheck struct {
 }
 
 func runHealthChecks(checks []HealthCheck) (issues issueEntries) {
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(len(checks))
+	issueChan := make(chan *issueEntry, len(checks))
+
 	for _, check := range checks {
-		log.Printf(" checking HTTP endpoint %s", check.RequestURL)
+		check := check
+		go func() {
+			issueChan <- runHealthCheck(check)
+			waitGroup.Done()
+		}()
+		// Introduce a small delay to prevent all checks to be started at the same time.
+		time.Sleep(10 * time.Millisecond)
+	}
 
-		// Set defaults
-		if check.RequestMethod == "" {
-			check.RequestMethod = "GET"
-		}
-		if check.ResponseStatusCodeEquals == 0 {
-			check.ResponseStatusCodeEquals = 200
-		}
+	waitGroup.Wait()
+	close(issueChan)
 
-		// Use retryablehttp to prevent false positives.
-		req, err := retryablehttp.NewRequest(check.RequestMethod, check.RequestURL, []byte(check.RequestBody))
-		if err != nil {
-			log.Printf("Health check %s: %s", check.RequestURL, err)
-			issues = append(issues, issueEntry{warning, fmt.Sprintf("%s: invalid health check", check.RequestURL)})
-			continue
-		}
-		for key, value := range check.RequestHeaders {
-			req.Header.Set(key, value)
-		}
-
-		resp, err := retryablehttp.NewClient().Do(req)
-		if err != nil {
-			issues = append(issues, issueEntry{danger, fmt.Sprintf("%s: cannot be reached", check.RequestURL)})
-			continue
-		}
-		if resp.StatusCode != check.ResponseStatusCodeEquals {
-			issues = append(issues, issueEntry{danger, fmt.Sprintf("%s: received unexpected status code %d", check.RequestURL, resp.StatusCode)})
-			continue
-		}
-
-		for key, value := range check.ResponseHeaderContains {
-			if resp.Header.Get(key) != value {
-				issues = append(issues, issueEntry{danger, fmt.Sprintf("%s: expected response header \"%s: %s\" could not be found", check.RequestURL, key, value)})
-			}
-		}
-
-		respBody, err := ioutil.ReadAll(resp.Body)
-		if !strings.Contains(string(respBody), check.ResponseBodyContains) {
-			issues = append(issues, issueEntry{danger, fmt.Sprintf("%s: expected response body \"%s\" could not be found", check.RequestURL, check.ResponseBodyContains)})
+	for issue := range issueChan {
+		if issue != nil {
+			issues = append(issues, *issue)
 		}
 	}
 	return
+}
+
+func runHealthCheck(check HealthCheck) *issueEntry {
+	log.Printf(" checking HTTP endpoint %s", check.RequestURL)
+
+	// Set defaults
+	if check.RequestMethod == "" {
+		check.RequestMethod = "GET"
+	}
+	if check.ResponseStatusCodeEquals == 0 {
+		check.ResponseStatusCodeEquals = 200
+	}
+
+	// Use retryablehttp to prevent false positives.
+	req, err := retryablehttp.NewRequest(check.RequestMethod, check.RequestURL, []byte(check.RequestBody))
+	if err != nil {
+		log.Printf("Health check %s: %s", check.RequestURL, err)
+		return &issueEntry{warning, fmt.Sprintf("%s: invalid health check", check.RequestURL)}
+	}
+	for key, value := range check.RequestHeaders {
+		req.Header.Set(key, value)
+	}
+
+	var intermediateIssue *issueEntry
+
+	client := retryablehttp.NewClient()
+	client.HTTPClient.Timeout = 3 * time.Second
+	client.CheckRetry = func(ctx context.Context, resp *http.Response, respErr error) (bool, error) {
+		retry, err2 := retryablehttp.DefaultRetryPolicy(ctx, resp, respErr)
+		if !retry {
+			return false, err2
+		}
+		if intermediateIssue == nil {
+			intermediateIssue = generateHealthCheckIssueEntry(check, resp, respErr)
+		}
+		return true, err2
+	}
+
+	resp, err := client.Do(req)
+	issue := generateHealthCheckIssueEntry(check, resp, err)
+	if issue != nil {
+		return issue
+	}
+
+	// Generate warning if health check was unstable.
+	if intermediateIssue != nil {
+		return &issueEntry{
+			issueType: warning,
+			message:   fmt.Sprintf("Unstable health check: %s", intermediateIssue.message),
+		}
+	}
+	return nil
+}
+
+func generateHealthCheckIssueEntry(check HealthCheck, resp *http.Response, respErr error) *issueEntry {
+	if respErr != nil {
+		return &issueEntry{danger, fmt.Sprintf("%s: cannot be reached", check.RequestURL)}
+	}
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return &issueEntry{danger, fmt.Sprintf("%s: response body could not be read", check.RequestURL)}
+	}
+	if resp.StatusCode != check.ResponseStatusCodeEquals {
+		return &issueEntry{danger, fmt.Sprintf("%s: received unexpected status code %d", check.RequestURL, resp.StatusCode)}
+	}
+
+	for key, value := range check.ResponseHeaderContains {
+		if resp.Header.Get(key) != value {
+			return &issueEntry{danger, fmt.Sprintf("%s: expected response header \"%s: %s\" could not be found", check.RequestURL, key, value)}
+		}
+	}
+
+	if !strings.Contains(string(respBody), check.ResponseBodyContains) {
+		return &issueEntry{danger, fmt.Sprintf("%s: expected response body \"%s\" could not be found", check.RequestURL, check.ResponseBodyContains)}
+	}
+	return nil
 }


### PR DESCRIPTION
I now use a timeout of 3 seconds (just like irmago does) and I execute all checks in parallel. This makes that we get an alert now already after 30 seconds of downtime. This is in my view a nice trade-off between filtering false positives and quick response.

I also added a warning message when the health checks are unstable.

Output of the current timings:

```
2022/06/17 14:56:55 [DEBUG] GET http://240.0.0.1
2022/06/17 14:56:55  checking HTTP endpoint https://privacybydesign.foundation
2022/06/17 14:56:55 [DEBUG] GET https://privacybydesign.foundation
2022/06/17 14:56:58 [ERR] GET http://240.0.0.1 request failed: Get "http://240.0.0.1": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2022/06/17 14:56:58 [DEBUG] GET http://240.0.0.1: retrying in 1s (4 left)
2022/06/17 14:57:02 [ERR] GET http://240.0.0.1 request failed: Get "http://240.0.0.1": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2022/06/17 14:57:02 [DEBUG] GET http://240.0.0.1: retrying in 2s (3 left)
2022/06/17 14:57:07 [ERR] GET http://240.0.0.1 request failed: Get "http://240.0.0.1": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2022/06/17 14:57:07 [DEBUG] GET http://240.0.0.1: retrying in 4s (2 left)
2022/06/17 14:57:14 [ERR] GET http://240.0.0.1 request failed: Get "http://240.0.0.1": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2022/06/17 14:57:14 [DEBUG] GET http://240.0.0.1: retrying in 8s (1 left)
2022/06/17 14:57:25 [ERR] GET http://240.0.0.1 request failed: Get "http://240.0.0.1": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2022/06/17 14:57:25 Issues found:

```