### PR TITLE
Debounce transient issues across check cycles

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -22,5 +22,11 @@ healthchecks:
 bindaddr: ':8079'
 interval: 5m
 
+# Number of consecutive check cycles an issue must be observed before it is
+# reported to Slack/webhooks. Higher values suppress transient blips (a host
+# briefly unreachable) at the cost of slower alerting on real outages.
+# Defaults to 3. Set to 1 to alert on the first failed cycle (old behaviour).
+failurethreshold: 3
+
 webhooks:
     - https://example.com/?message=%s

--- a/main.go
+++ b/main.go
@@ -84,6 +84,10 @@ var (
 	initialCheck   bool
 	issues         issueEntries
 	parsedTemplate *template.Template
+
+	// failureStreaks tracks, per issue message, how many consecutive check
+	// cycles it has been observed. Used to debounce transient blips.
+	failureStreaks = map[string]int{}
 )
 
 // Configuration
@@ -96,6 +100,7 @@ type Conf struct {
 	Interval               time.Duration
 	SlackWebhooks          []string
 	WebHooks               []string
+	FailureThreshold       int // consecutive cycles an issue must persist before it is reported
 }
 
 func main() {
@@ -104,6 +109,7 @@ func main() {
 	// set configuration defaults
 	conf.BindAddr = ":8080"
 	conf.Interval = 5 * time.Minute
+	conf.FailureThreshold = 3
 
 	// parse commandline
 	flag.StringVar(&confPath, "config", "config.yaml",
@@ -128,6 +134,12 @@ func main() {
 
 	if err := yaml.Unmarshal(buf, &conf); err != nil {
 		log.Fatalf("Could not parse config file: %s", err)
+	}
+
+	// A threshold below 1 would mean "report before observing", which makes no
+	// sense; clamp it so a value of 1 reproduces the old alert-immediately behaviour.
+	if conf.FailureThreshold < 1 {
+		conf.FailureThreshold = 1
 	}
 
 	// Load IRMA configuration
@@ -226,7 +238,12 @@ func runChecks(irmaConfig *irma.Configuration) {
 
 	logCurrentIssues(curIssues.messages())
 
-	newIssues, fixedIssues := difference(issues, curIssues)
+	// Debounce transient blips: only treat an issue as confirmed once it has
+	// been observed for conf.FailureThreshold consecutive cycles. A host that is
+	// briefly unreachable and recovers within a cycle or two is never reported.
+	confirmedIssues := confirmIssues(curIssues)
+
+	newIssues, fixedIssues := difference(issues, confirmedIssues)
 
 	if len(conf.SlackWebhooks) > 0 {
 		go pushToSlack(newIssues, fixedIssues, initialCheck)
@@ -237,9 +254,44 @@ func runChecks(irmaConfig *irma.Configuration) {
 		go pushToWebHooks(newIssues)
 	}
 
-	issues = curIssues
+	issues = confirmedIssues
 	initialCheck = false
 	lastCheck = time.Now()
+}
+
+// confirmIssues applies cross-cycle debouncing. It tracks how many consecutive
+// cycles each issue (keyed by message) has been observed and returns only those
+// that have reached conf.FailureThreshold. Issues that are absent this cycle
+// have their streak reset, so a recovered blip starts counting from scratch if
+// it ever returns.
+func confirmIssues(curIssues issueEntries) (confirmed issueEntries) {
+	curMessages := make(map[string]bool, len(curIssues))
+	for _, issue := range curIssues {
+		curMessages[issue.message] = true
+	}
+
+	// Reset streaks for issues that are no longer present.
+	for msg := range failureStreaks {
+		if !curMessages[msg] {
+			delete(failureStreaks, msg)
+		}
+	}
+
+	var pending []string
+	for _, issue := range curIssues {
+		failureStreaks[issue.message]++
+		if failureStreaks[issue.message] >= conf.FailureThreshold {
+			confirmed = append(confirmed, issue)
+		} else {
+			pending = append(pending, fmt.Sprintf("%s (%d/%d)", issue.message, failureStreaks[issue.message], conf.FailureThreshold))
+		}
+	}
+
+	if len(pending) > 0 {
+		log.Printf("Pending issues (awaiting confirmation):\n%s", strings.Join(pending, "\n"))
+	}
+
+	return
 }
 
 func pushToWebHooks(newIssues issueEntries) {

--- a/main.go
+++ b/main.go
@@ -88,6 +88,13 @@ var (
 	// failureStreaks tracks, per issue message, how many consecutive check
 	// cycles it has been observed. Used to debounce transient blips.
 	failureStreaks = map[string]int{}
+
+	// cycleCount counts how many check cycles have run since (re)start. It drives
+	// the initialCheck window: an issue present from the very first cycle is only
+	// confirmed once its streak reaches conf.FailureThreshold (i.e. at cycle
+	// conf.FailureThreshold), so the "this might be pre-existing" startup window
+	// must stay open that long rather than closing after the first cycle.
+	cycleCount int
 )
 
 // Configuration
@@ -181,7 +188,6 @@ func main() {
 	ticker = time.NewTicker(conf.Interval)
 
 	go func() {
-		initialCheck = true
 		for {
 			runChecks(irmaConfig)
 			<-ticker.C
@@ -230,6 +236,15 @@ func difference(old, cur issueEntries) (came, gone issueEntries) {
 func runChecks(irmaConfig *irma.Configuration) {
 	var curIssues issueEntries
 
+	// An issue that has been failing since startup is only confirmed once its
+	// streak reaches conf.FailureThreshold, which happens on cycle
+	// conf.FailureThreshold. Treat every cycle up to and including that one as
+	// "initial", so a pre-existing outage that surfaces under debouncing is still
+	// recognised as a restart artefact (suppressed from webhooks, flagged with
+	// the "I just (re)started" Slack preamble) rather than paged as brand new.
+	cycleCount++
+	initialCheck = cycleCount <= conf.FailureThreshold
+
 	log.Println("Running checks ...")
 	curIssues = append(curIssues, checkSchemeManagers(irmaConfig)...)
 	curIssues = append(curIssues, checkCertificateExpiry()...)
@@ -255,7 +270,6 @@ func runChecks(irmaConfig *irma.Configuration) {
 	}
 
 	issues = confirmedIssues
-	initialCheck = false
 	lastCheck = time.Now()
 }
 

--- a/main.go
+++ b/main.go
@@ -291,8 +291,17 @@ func confirmIssues(curIssues issueEntries) (confirmed issueEntries) {
 		}
 	}
 
+	// Count each distinct message at most once per cycle, so two entries with
+	// the same message (e.g. duplicate health checks on one URL) can't advance
+	// the streak twice or land in confirmed twice.
 	var pending []string
+	counted := make(map[string]bool, len(curIssues))
 	for _, issue := range curIssues {
+		if counted[issue.message] {
+			continue
+		}
+		counted[issue.message] = true
+
 		failureStreaks[issue.message]++
 		if failureStreaks[issue.message] >= conf.FailureThreshold {
 			confirmed = append(confirmed, issue)

--- a/main_test.go
+++ b/main_test.go
@@ -51,6 +51,28 @@ func TestConfirmIssuesReportsPersistentIssue(t *testing.T) {
 	}
 }
 
+func TestConfirmIssuesDeduplicatesMessagesWithinCycle(t *testing.T) {
+	resetDebounceState(3)
+
+	msg := "yivi.app: cannot be reached"
+	// Two entries with the same message in a single cycle (e.g. duplicate health
+	// checks on one URL) must advance the streak by one, not two, and must not
+	// land in the confirmed set twice.
+	dup := issueEntries{issue(msg), issue(msg)}
+
+	for cycle := 1; cycle <= 2; cycle++ {
+		if got := confirmedMessages(dup); len(got) != 0 {
+			t.Fatalf("cycle %d: expected not yet confirmed, got %v", cycle, got)
+		}
+	}
+	// Only on the third consecutive cycle does the streak reach the threshold,
+	// and the message is confirmed exactly once.
+	got := confirmedMessages(dup)
+	if len(got) != 1 || got[0] != msg {
+		t.Fatalf("cycle 3: expected %q confirmed exactly once, got %v", msg, got)
+	}
+}
+
 func TestConfirmIssuesThresholdOneAlertsImmediately(t *testing.T) {
 	resetDebounceState(1)
 

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,8 @@ import "testing"
 func resetDebounceState(threshold int) {
 	failureStreaks = map[string]int{}
 	conf.FailureThreshold = threshold
+	cycleCount = 0
+	initialCheck = false
 }
 
 func issue(msg string) issueEntry {
@@ -97,5 +99,68 @@ func TestDebounceEndToEnd(t *testing.T) {
 	_, f := step(issueEntries{})
 	if len(f) != 1 || f[0].message != persistent {
 		t.Fatalf("cycle 5: expected %q reported as fixed, got %v", persistent, f.messages())
+	}
+}
+
+// stepInitialWindow mirrors the initialCheck bookkeeping at the top of runChecks
+// and returns whether the cycle is treated as initial.
+func stepInitialWindow() bool {
+	cycleCount++
+	initialCheck = cycleCount <= conf.FailureThreshold
+	return initialCheck
+}
+
+// TestInitialCheckWindowCoversDebounceDelay verifies that the initialCheck
+// window stays open long enough for a startup-present issue to be confirmed.
+// Under debouncing such an issue only surfaces on cycle == FailureThreshold, so
+// closing the window after the first cycle (the previous behaviour) would let a
+// restart-time outage page as brand new and kill the restart Slack preamble.
+func TestInitialCheckWindowCoversDebounceDelay(t *testing.T) {
+	resetDebounceState(3)
+
+	startupIssue := "yivi.app: cannot be reached"
+
+	// Cycles 1 and 2: the issue is detected but not yet confirmed; the window
+	// must remain open so it is still considered initial once it is confirmed.
+	for cycle := 1; cycle <= 2; cycle++ {
+		initial := stepInitialWindow()
+		if got := confirmedMessages(issueEntries{issue(startupIssue)}); len(got) != 0 {
+			t.Fatalf("cycle %d: expected not yet confirmed, got %v", cycle, got)
+		}
+		if !initial {
+			t.Fatalf("cycle %d: expected initialCheck to still be true", cycle)
+		}
+	}
+
+	// Cycle 3: the startup issue is confirmed for the first time and must still
+	// be flagged initial, so it is suppressed from webhooks and the restart
+	// preamble fires.
+	initial := stepInitialWindow()
+	got := confirmedMessages(issueEntries{issue(startupIssue)})
+	if len(got) != 1 || got[0] != startupIssue {
+		t.Fatalf("cycle 3: expected %q confirmed, got %v", startupIssue, got)
+	}
+	if !initial {
+		t.Fatalf("cycle 3: expected initialCheck to be true when the startup issue is first confirmed")
+	}
+
+	// Cycle 4 onwards: the startup window is closed; a genuinely new issue that
+	// appears later must page normally (not be treated as a restart artefact).
+	if initial := stepInitialWindow(); initial {
+		t.Fatalf("cycle 4: expected initialCheck to be false once the startup window has passed")
+	}
+}
+
+// TestInitialCheckThresholdOneMatchesOldBehaviour confirms that with
+// FailureThreshold == 1 only the very first cycle is initial, exactly
+// reproducing the pre-debounce semantics.
+func TestInitialCheckThresholdOneMatchesOldBehaviour(t *testing.T) {
+	resetDebounceState(1)
+
+	if initial := stepInitialWindow(); !initial {
+		t.Fatalf("cycle 1: expected initialCheck to be true")
+	}
+	if initial := stepInitialWindow(); initial {
+		t.Fatalf("cycle 2: expected initialCheck to be false")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,101 @@
+package main
+
+import "testing"
+
+// resetDebounceState clears the global debounce state between test cases.
+func resetDebounceState(threshold int) {
+	failureStreaks = map[string]int{}
+	conf.FailureThreshold = threshold
+}
+
+func issue(msg string) issueEntry {
+	return issueEntry{danger, msg}
+}
+
+// confirmedMessages runs one debounce cycle and returns the confirmed messages.
+func confirmedMessages(cur issueEntries) []string {
+	return confirmIssues(cur).messages()
+}
+
+func TestConfirmIssuesSuppressesSingleCycleBlip(t *testing.T) {
+	resetDebounceState(3)
+
+	// A blip that appears for one cycle and then recovers must never be confirmed.
+	if got := confirmedMessages(issueEntries{issue("yivi.app: cannot be reached")}); len(got) != 0 {
+		t.Fatalf("cycle 1: expected nothing confirmed, got %v", got)
+	}
+	if got := confirmedMessages(issueEntries{}); len(got) != 0 {
+		t.Fatalf("cycle 2 (recovered): expected nothing confirmed, got %v", got)
+	}
+	// Streak must have been reset, so the issue counts from scratch if it returns.
+	if got := confirmedMessages(issueEntries{issue("yivi.app: cannot be reached")}); len(got) != 0 {
+		t.Fatalf("cycle 3 (returned): expected nothing confirmed, got %v", got)
+	}
+}
+
+func TestConfirmIssuesReportsPersistentIssue(t *testing.T) {
+	resetDebounceState(3)
+
+	msg := "privacybydesign.foundation: cannot be reached"
+	for cycle := 1; cycle <= 2; cycle++ {
+		if got := confirmedMessages(issueEntries{issue(msg)}); len(got) != 0 {
+			t.Fatalf("cycle %d: expected not yet confirmed, got %v", cycle, got)
+		}
+	}
+	// Third consecutive cycle: the threshold is reached and the issue is confirmed.
+	got := confirmedMessages(issueEntries{issue(msg)})
+	if len(got) != 1 || got[0] != msg {
+		t.Fatalf("cycle 3: expected %q confirmed, got %v", msg, got)
+	}
+}
+
+func TestConfirmIssuesThresholdOneAlertsImmediately(t *testing.T) {
+	resetDebounceState(1)
+
+	msg := "schemes.yivi.app: cannot be reached"
+	got := confirmedMessages(issueEntries{issue(msg)})
+	if len(got) != 1 || got[0] != msg {
+		t.Fatalf("threshold 1: expected immediate confirmation, got %v", got)
+	}
+}
+
+// TestDebounceEndToEnd mirrors the runChecks reporting loop: an issue should be
+// reported as "new" only once confirmed, and a transient blip should produce no
+// new/fixed churn at all.
+func TestDebounceEndToEnd(t *testing.T) {
+	resetDebounceState(2)
+
+	var reported issueEntries // plays the role of the global `issues`
+	step := func(cur issueEntries) (newIssues, fixedIssues issueEntries) {
+		confirmed := confirmIssues(cur)
+		newIssues, fixedIssues = difference(reported, confirmed)
+		reported = confirmed
+		return
+	}
+
+	blip := "yivi.app: cannot be reached"
+
+	// Cycle 1: blip detected but not yet confirmed -> no alert.
+	if n, f := step(issueEntries{issue(blip)}); len(n) != 0 || len(f) != 0 {
+		t.Fatalf("cycle 1: expected no churn, got new=%v fixed=%v", n, f)
+	}
+	// Cycle 2: blip recovered -> still no alert and nothing to mark fixed.
+	if n, f := step(issueEntries{}); len(n) != 0 || len(f) != 0 {
+		t.Fatalf("cycle 2: expected no churn, got new=%v fixed=%v", n, f)
+	}
+
+	// Now a genuinely persistent issue across two cycles.
+	persistent := "keyshare.yivi.app: cannot be reached"
+	if n, _ := step(issueEntries{issue(persistent)}); len(n) != 0 {
+		t.Fatalf("cycle 3: expected not yet reported, got new=%v", n)
+	}
+	n, _ := step(issueEntries{issue(persistent)})
+	if len(n) != 1 || n[0].message != persistent {
+		t.Fatalf("cycle 4: expected %q reported as new, got %v", persistent, n.messages())
+	}
+	// Recovery is reported as fixed exactly once.
+	_, f := step(issueEntries{})
+	if len(f) != 1 || f[0].message != persistent {
+		t.Fatalf("cycle 5: expected %q reported as fixed, got %v", persistent, f.messages())
+	}
+}


### PR DESCRIPTION
Closes #21

## Problem

The watchdog fires recurring false-positive alerts: a host is briefly unreachable (a few seconds to a couple of minutes — e.g. a shared ingress/CDN reloading), the check fails, and a `@channel` "New issues discovered" alert goes out. By the next cycle the blip is over, so a "fixed" alert follows minutes later. The sites are actually up the whole time.

The root cause on the watchdog side: the in-cycle retry window (~25s at most) is far shorter than real blip durations, and there was **no debouncing across cycles** — a single bad cycle immediately alerted, and the next good cycle immediately marked it fixed.

## Change

Add cross-cycle debouncing. An issue is only reported once it has been observed for `FailureThreshold` **consecutive** check cycles; its streak resets whenever it recovers. The new/fixed diff now runs against this *confirmed* set, so a single-cycle blip produces no alert churn at all.

- New config option `failurethreshold` (default **3**, clamped to a minimum of 1). With the 5m interval, an issue must persist ~10 min before it pages; genuine outages still alert, transient blips are suppressed. `1` reproduces the previous alert-immediately behaviour.
- Detected-but-unconfirmed issues are logged each cycle (`Pending issues (awaiting confirmation): … (1/3)`) for visibility.
- The status page and `fixed` reporting reflect the confirmed set, keeping the page consistent with what is alerted.
- Documented the option in `config.yaml.example`.

## Tests

`main_test.go` covers single-cycle blip suppression, streak reset on recovery, persistent-issue confirmation at the threshold, `threshold=1` immediate alerting, and the end-to-end new/fixed reporting loop.

## Rollout

The default of 3 takes effect on deploy — no ops change required. To tune without a rebuild, add `failurethreshold: <n>` to `config.prod.yaml` / `config.dev.yaml` in `watchdogd-ops`.

## Note

This is a debounce, not a root-cause fix. If the underlying blips turn out to be the low pod CPU limit (40m) or cluster DNS, those remain worth addressing separately once alert volume drops.