### PR TITLE
Log per-phase connection timing for failed checks

### DIFF
--- a/health_check.go
+++ b/health_check.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/http/httptrace"
 	"strings"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -63,6 +64,14 @@ func runHealthCheck(client *retryablehttp.Client, check HealthCheck) *issueEntry
 		req.Header.Set(key, value)
 	}
 
+	// Record per-attempt connection timings so a failure tells us which phase
+	// (DNS, connect, TLS, first byte) was slow or hung, from the pod's vantage.
+	trace := newRequestTrace()
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace.clientTrace()))
+	client.RequestLogHook = func(_ retryablehttp.Logger, _ *http.Request, attempt int) {
+		trace.reset(attempt)
+	}
+
 	var issue *issueEntry
 
 	client.CheckRetry = func(ctx context.Context, resp *http.Response, respErr error) (bool, error) {
@@ -77,6 +86,7 @@ func runHealthCheck(client *retryablehttp.Client, check HealthCheck) *issueEntry
 		if newIssue == nil {
 			return false, nil
 		}
+		logFailedAttempt(check.RequestMethod, check.RequestURL, trace, respErr)
 		issue = newIssue
 		return true, nil
 	}

--- a/main.go
+++ b/main.go
@@ -7,12 +7,14 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"html/template"
 	"io"
 	"log"
 	"net/http"
+	"net/http/httptrace"
 	"net/url"
 	"os"
 	"path"
@@ -363,7 +365,29 @@ func checkCertificateExpiry() (ret issueEntries) {
 
 func checkCertificateExpiryOf(client *retryablehttp.Client, url string) (ret issueEntries) {
 	log.Printf(" checking certificate expiry on %s", url)
-	resp, err := client.Head(url)
+
+	req, err := retryablehttp.NewRequest(http.MethodHead, url, nil)
+	if err != nil {
+		ret = append(ret, issueEntry{warning, fmt.Sprintf("%s: invalid certificate check: %s", url, err)})
+		return
+	}
+
+	// Record per-attempt connection timings so a failure tells us which phase
+	// (DNS, connect, TLS, first byte) was slow or hung, from the pod's vantage.
+	trace := newRequestTrace()
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace.clientTrace()))
+	client.RequestLogHook = func(_ retryablehttp.Logger, _ *http.Request, attempt int) {
+		trace.reset(attempt)
+	}
+	client.CheckRetry = func(ctx context.Context, resp *http.Response, respErr error) (bool, error) {
+		shouldRetry, retErr := retryablehttp.DefaultRetryPolicy(ctx, resp, respErr)
+		if respErr != nil || shouldRetry {
+			logFailedAttempt(http.MethodHead, url, trace, respErr)
+		}
+		return shouldRetry, retErr
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		ret = append(ret, issueEntry{warning, fmt.Sprintf("%s: error %s", url, err)})
 		return

--- a/timing.go
+++ b/timing.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http/httptrace"
+	"sync"
+	"time"
+)
+
+// requestTrace captures the connection-phase timings of a single HTTP attempt
+// using net/http/httptrace. When a check fails or is slow we can then see which
+// phase (DNS resolution, TCP connect, TLS handshake, or waiting for the first
+// response byte) was responsible — measured from the watchdog's own vantage
+// point, which is what we cannot observe from a browser on a workstation.
+type requestTrace struct {
+	mu sync.Mutex
+
+	attempt int
+
+	start     time.Time
+	dnsStart  time.Time
+	dnsDone   time.Time
+	connStart time.Time
+	connDone  time.Time
+	tlsStart  time.Time
+	tlsDone   time.Time
+	firstByte time.Time
+	reused    bool
+}
+
+func newRequestTrace() *requestTrace {
+	return &requestTrace{start: time.Now()}
+}
+
+// clientTrace returns an httptrace.ClientTrace that records phase timestamps
+// into t. Attach it to a request context with httptrace.WithClientTrace.
+func (t *requestTrace) clientTrace() *httptrace.ClientTrace {
+	return &httptrace.ClientTrace{
+		DNSStart:             func(httptrace.DNSStartInfo) { t.mark(&t.dnsStart) },
+		DNSDone:              func(httptrace.DNSDoneInfo) { t.mark(&t.dnsDone) },
+		ConnectStart:         func(_, _ string) { t.mark(&t.connStart) },
+		ConnectDone:          func(_, _ string, _ error) { t.mark(&t.connDone) },
+		TLSHandshakeStart:    func() { t.mark(&t.tlsStart) },
+		TLSHandshakeDone:     func(tls.ConnectionState, error) { t.mark(&t.tlsDone) },
+		GotFirstResponseByte: func() { t.mark(&t.firstByte) },
+		GotConn: func(info httptrace.GotConnInfo) {
+			t.mu.Lock()
+			t.reused = info.Reused
+			t.mu.Unlock()
+		},
+	}
+}
+
+// mark records the current time into field, but only the first time it fires
+// within an attempt (some phases, e.g. connect on dual-stack hosts, fire twice).
+func (t *requestTrace) mark(field *time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if field.IsZero() {
+		*field = time.Now()
+	}
+}
+
+// reset clears the timings at the start of each attempt. retryablehttp reuses
+// the same request (and therefore the same trace) across retries, so without
+// this the timings of a later attempt would be masked by an earlier one.
+func (t *requestTrace) reset(attempt int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.attempt = attempt
+	t.start = time.Now()
+	t.dnsStart, t.dnsDone = time.Time{}, time.Time{}
+	t.connStart, t.connDone = time.Time{}, time.Time{}
+	t.tlsStart, t.tlsDone = time.Time{}, time.Time{}
+	t.firstByte = time.Time{}
+	t.reused = false
+}
+
+// summary renders a one-line, human-readable breakdown of the attempt. Phases
+// that did not complete are shown as "-", which itself is diagnostic: a hung TLS
+// handshake shows "tls=-", a DNS timeout shows everything after dns as "-".
+func (t *requestTrace) summary() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	phase := func(start, end time.Time) string {
+		if start.IsZero() || end.IsZero() {
+			return "-"
+		}
+		return end.Sub(start).Round(time.Millisecond).String()
+	}
+
+	ttfb := "-"
+	if !t.firstByte.IsZero() {
+		ttfb = t.firstByte.Sub(t.start).Round(time.Millisecond).String()
+	}
+
+	return fmt.Sprintf("dns=%s connect=%s tls=%s ttfb=%s total=%s reused=%t",
+		phase(t.dnsStart, t.dnsDone),
+		phase(t.connStart, t.connDone),
+		phase(t.tlsStart, t.tlsDone),
+		ttfb,
+		time.Since(t.start).Round(time.Millisecond),
+		t.reused,
+	)
+}
+
+// logFailedAttempt emits the phase breakdown for an attempt that errored or was
+// otherwise unhealthy. Healthy attempts are not logged, so normal cycles stay
+// quiet and the only trace output is for the events we want to diagnose.
+func logFailedAttempt(method, url string, t *requestTrace, err error) {
+	if err != nil {
+		log.Printf("trace %s %s attempt %d failed (%s) err=%s", method, url, t.attempt, t.summary(), err)
+	} else {
+		log.Printf("trace %s %s attempt %d unhealthy (%s)", method, url, t.attempt, t.summary())
+	}
+}

--- a/timing_test.go
+++ b/timing_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// TestRequestTraceCapturesPhases runs a real request through the same wiring the
+// checks use and confirms the connection phases are recorded.
+func TestRequestTraceCapturesPhases(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := newHTTPClient()
+	req, err := retryablehttp.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	trace := newRequestTrace()
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace.clientTrace()))
+	client.RequestLogHook = func(_ retryablehttp.Logger, _ *http.Request, attempt int) {
+		trace.reset(attempt)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	s := trace.summary()
+	if strings.Contains(s, "connect=-") {
+		t.Errorf("expected TCP connect phase to be recorded, got %q", s)
+	}
+	if strings.Contains(s, "ttfb=-") {
+		t.Errorf("expected time-to-first-byte to be recorded, got %q", s)
+	}
+}
+
+// TestRequestTraceSummaryShowsIncompletePhases is the diagnostic payoff: a phase
+// that never completes must render as "-" so the log pinpoints where it hung.
+func TestRequestTraceSummaryShowsIncompletePhases(t *testing.T) {
+	now := time.Now()
+	tr := &requestTrace{
+		start:     now,
+		connStart: now,
+		connDone:  now.Add(10 * time.Millisecond),
+		tlsStart:  now.Add(10 * time.Millisecond),
+		// tlsDone left zero -> handshake hung; firstByte zero -> no response
+	}
+
+	s := tr.summary()
+	if !strings.Contains(s, "tls=-") {
+		t.Errorf("expected tls=- for an incomplete handshake, got %q", s)
+	}
+	if !strings.Contains(s, "ttfb=-") {
+		t.Errorf("expected ttfb=- when no first byte arrived, got %q", s)
+	}
+	if strings.Contains(s, "connect=-") {
+		t.Errorf("expected the completed connect phase to show a duration, got %q", s)
+	}
+}
+
+func TestRequestTraceResetClearsPhases(t *testing.T) {
+	tr := newRequestTrace()
+	tr.mark(&tr.dnsStart)
+	tr.mark(&tr.connStart)
+
+	tr.reset(2)
+
+	if tr.attempt != 2 {
+		t.Errorf("attempt = %d, want 2", tr.attempt)
+	}
+	if !tr.dnsStart.IsZero() || !tr.connStart.IsZero() {
+		t.Errorf("reset did not clear phase timestamps: %s", tr.summary())
+	}
+}


### PR DESCRIPTION
## Why

When a check fails we currently see only `context deadline exceeded (Client.Timeout exceeded while awaiting headers)` — with no indication of *which* phase ate the 5s budget. And `client.Logger` was `nil`, so the retries left no trace at all. That makes it impossible to tell, after the fact, whether a transient alert was:

- a real brief blip of the (shared) front-end,
- slow cluster DNS (CoreDNS / `ndots`),
- a stalled TLS handshake, or
- CPU throttling on the pod (40m limit; TLS is CPU-bursty).

We keep seeing alerts that resolve themselves within minutes while the sites look fine from a browser — but a browser is a different vantage point than the pod. This adds the evidence needed to find the actual root cause from the pod's perspective.

## What

Attach `net/http/httptrace` to each check request and, on any failed or unhealthy attempt, log a one-line phase breakdown:

```
trace HEAD https://yivi.app attempt 3 failed (dns=12ms connect=8ms tls=- ttfb=- total=5.00s reused=false) err=Head "https://yivi.app": context deadline exceeded ...
```

- Each phase (DNS, TCP connect, TLS handshake, time-to-first-byte) is timed independently.
- A phase that never completed renders as `-`, which is itself the diagnosis: `tls=-` means the handshake never finished; everything `-` after `dns` means DNS hung.
- `reused` shows whether the connection was a keep-alive reuse.
- The trace is reset per attempt (retryablehttp reuses the request across retries), so each retry's timing is reported on its own.
- **Healthy attempts are not logged**, so normal cycles stay quiet — the only trace output is for the events we want to diagnose.
- Covers both the certificate-expiry `HEAD` checks (`main.go`) and the health-check requests (`health_check.go`).

## How to use it

After deploy, the next time an alert fires, grep the pod logs for `trace ` around that timestamp. The phase that shows `-` or a multi-second duration is the culprit, and you can compare it against cluster DNS / CPU-throttle metrics for the same moment.

## Notes

- No config or behavior change to the checks themselves — this is observability only. Timeout/retry tuning and the debounce are separate PRs.
- Tests cover a real request through the full client wiring, the incomplete-phase rendering, and per-attempt reset (`go test -race` clean).